### PR TITLE
require % prefix on raw commands

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -265,9 +265,10 @@ class Bot {
     }
 
     let text = this.parseText(message.getBody());
-    const cmdMatch = (/^[A-Z]+\s\S/).test(text);
+    const cmdMatch = (/^%[A-Z]{3,}\s\S/).test(text);
 
     if (cmdMatch) {
+      text = text.replace(/^%/,'');
       logger.debug('Sending raw command to IRC', text);
       this.ircClient.send(...text.split(' '));
       channel.send(`_sent raw command_`);


### PR DESCRIPTION
e.g. `%PRIVMSG andytuba ping`

also validates that command is a least 3 characters long
